### PR TITLE
Fix bar chart template labeling and sizing

### DIFF
--- a/RNKoreBotSDK/bot-sdk/templates/charts/BarChartTemplate.tsx
+++ b/RNKoreBotSDK/bot-sdk/templates/charts/BarChartTemplate.tsx
@@ -23,13 +23,13 @@ export default class BarChartTemplate extends BaseView<
   BarChartState
 > {
   private renderBarChartView = (payload: any) => {
-    let elementSize = 0;
+    // Calculate the maximum length across all datasets to handle differing dataset sizes
+    let elementSize = Math.max(...(payload?.elements?.map((element: any) => element.values.length) || [0]));
     let dataSet = payload?.elements?.flatMap((element: any, index: number) => {
-      elementSize = element.values.length;
       return element.values.map((value: any, i) => ({
         value: value,
-        label: index === 1 ? payload?.X_axis[i] : '',
-        frontColor: MATERIAL_COLORS[index],// Always using the second color (index 1)
+        label: index === 0 ? payload?.X_axis[i] || '' : '', // Only assign labels to the first dataset
+        frontColor: MATERIAL_COLORS[index], // Using different colors for each dataset based on index
         spacing: 5,
         legend: element.title
       }));


### PR DESCRIPTION
Fix `BarChartTemplate` issues with X-axis labels, `elementSize` calculation, and a misleading comment to improve chart rendering robustness.

The original implementation had X-axis labels only applied to the second dataset, `elementSize` incorrectly reflected only the last dataset's length (leading to potential out-of-bounds errors), and a comment inaccurately described color assignment. This PR corrects these to ensure proper labeling, safe handling of varying dataset lengths, and accurate code documentation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1ef9a25d-13dc-4ac9-9687-3984fb688692) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1ef9a25d-13dc-4ac9-9687-3984fb688692)